### PR TITLE
Align remote drift trails with interpolated car positions

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -575,10 +575,12 @@ class Game {
         this.camera.setScale(this.worldScale);
         this.camera.moveTowards(localPlayer.car.position);
 
+        let trailRenderTimeMs = Date.now();
         // Interpolate remote players (skip in training mode)
         if (!this.trainingEnabled) {
             const renderTime = this.net.serverNowMs() - 100;
             this.playerManager.interpolateRemotes(renderTime, renderTime - 1000, this.net.socketId);
+            trailRenderTimeMs = renderTime;
         }
 
         this.checkIdlePlayers();
@@ -599,7 +601,8 @@ class Game {
             lapCounter: this.playerManager.getLapCounter(),
             track: this.track,
             worldScale: this.worldScale,
-            frameStepMs: this._lastStepMs
+            frameStepMs: this._lastStepMs,
+            trailRenderTimeMs
         });
 
         // Update UI with scores

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -45,6 +45,9 @@ import { GameEventBus, GameEvents } from "./runtime/events/GameEvents";
 import GameState from "./runtime/state/GameState";
 import { DEFAULT_CANVAS_VISIBLE_FACTOR, DEFAULT_MAP_SIZE, DEFAULT_MINIMAP_SIZE, DEFAULT_PLAYER_NAME, SCHEDULER_INTERVALS } from "./config/RuntimeConfig";
 
+// Render remote players slightly in the past so interpolation has future snapshots available.
+const REMOTE_INTERPOLATION_DELAY_MS = 100;
+
 export interface GameRuntimeServices {
     eventBus?: GameEventBus;
     state?: GameState;
@@ -578,7 +581,7 @@ class Game {
         let trailRenderTimeMs = Date.now();
         // Interpolate remote players (skip in training mode)
         if (!this.trainingEnabled) {
-            const renderTime = this.net.serverNowMs() - 100;
+            const renderTime = this.net.serverNowMs() - REMOTE_INTERPOLATION_DELAY_MS;
             this.playerManager.interpolateRemotes(renderTime, renderTime - 1000, this.net.socketId);
             trailRenderTimeMs = renderTime;
         }

--- a/src/components/Player/Player.ts
+++ b/src/components/Player/Player.ts
@@ -26,6 +26,7 @@ export default class Player {
     id: string;
     snapshotBuffer: SnapshotBuffer;
     pendingTrailStamps: TrailStamp[];
+    lastRemoteSampleMs: number | null;
     
     // Boost system
     boostCharge: number = 0;
@@ -52,6 +53,7 @@ export default class Player {
         this.lastDriftTime = 0;
         this.snapshotBuffer = new SnapshotBuffer();
         this.pendingTrailStamps = [];
+        this.lastRemoteSampleMs = null;
         
         // Initialize lap timing
         this.lastPos = null;

--- a/src/net/Interpolator.ts
+++ b/src/net/Interpolator.ts
@@ -4,6 +4,7 @@ export interface InterpolatedState {
     x: number;
     y: number;
     angle: number;
+    sampledTimeMs: number;
 }
 
 export default class Interpolator {
@@ -22,14 +23,16 @@ export default class Interpolator {
                 return {
                     x: p0!.x + p0!.vx * dt,
                     y: p0!.y + p0!.vy * dt,
-                    angle: p0!.angle + p0!.angVel * dt
+                    angle: p0!.angle + p0!.angVel * dt,
+                    sampledTimeMs: renderTime
                 };
             }
             // Too old, just use the snapshot
             return {
                 x: p0!.x,
                 y: p0!.y,
-                angle: p0!.angle
+                angle: p0!.angle,
+                sampledTimeMs: p0!.tMs
             };
         }
 
@@ -38,7 +41,8 @@ export default class Interpolator {
             return {
                 x: p1.x,
                 y: p1.y,
-                angle: p1.angle
+                angle: p1.angle,
+                sampledTimeMs: p1.tMs
             };
         }
 
@@ -48,11 +52,13 @@ export default class Interpolator {
             return {
                 x: p1.x,
                 y: p1.y,
-                angle: p1.angle
+                angle: p1.angle,
+                sampledTimeMs: p1.tMs
             };
         }
 
-        const t = (renderTime - p0.tMs) / totalTime;
+        const clampedRenderTime = Math.max(p0.tMs, Math.min(renderTime, p1.tMs));
+        const t = (clampedRenderTime - p0.tMs) / totalTime;
         const clampedT = Math.max(0, Math.min(1, t));
 
         // Cubic Hermite interpolation for position
@@ -72,7 +78,8 @@ export default class Interpolator {
         return {
             x: pos.x,
             y: pos.y,
-            angle: angle
+            angle: angle,
+            sampledTimeMs: p0.tMs + clampedT * totalTime
         };
     }
 

--- a/src/net/ServerMessageTranslator.ts
+++ b/src/net/ServerMessageTranslator.ts
@@ -10,8 +10,12 @@ export interface TranslatedMessage {
 }
 
 export function translatePlayerState(state: PlayerStateMessage): TranslatedMessage {
+  const clientTimestamp = Number(state.tMs);
+  const serverTimestamp = Number(state.tServerMs ?? state.tMs);
+  const stampTimeOffset = serverTimestamp - clientTimestamp;
+
   const snapshot: Snapshot = {
-    tMs: state.tServerMs || state.tMs,
+    tMs: serverTimestamp,
     x: state.car.position.x,
     y: state.car.position.y,
     vx: state.car.vx,
@@ -27,18 +31,23 @@ export function translatePlayerState(state: PlayerStateMessage): TranslatedMessa
     },
   };
 
-  const trailStamps: TrailStamp[] = (state.stamps || []).map((stamp: any) => ({
-    x: stamp.x,
-    y: stamp.y,
-    angle: stamp.angle,
-    weight: stamp.weight,
-    h: stamp.h,
-    s: stamp.s,
-    b: stamp.b,
-    overscore: stamp.overscore,
-    tMs: stamp.tMs,
-    a: stamp.a,
-  }));
+  const trailStamps: TrailStamp[] = (state.stamps || []).map((stamp: any) => {
+    const rawStampTime = stamp.tMs !== undefined ? Number(stamp.tMs) : clientTimestamp;
+    const alignedStampTime = rawStampTime + stampTimeOffset;
+
+    return {
+      x: stamp.x,
+      y: stamp.y,
+      angle: stamp.angle,
+      weight: stamp.weight,
+      h: stamp.h,
+      s: stamp.s,
+      b: stamp.b,
+      overscore: stamp.overscore,
+      tMs: alignedStampTime,
+      a: stamp.a,
+    };
+  });
 
   const bursts: SparkBurst[] = (state.bursts || []).map((burst: any) => ({
     x: burst.x,
@@ -49,7 +58,7 @@ export function translatePlayerState(state: PlayerStateMessage): TranslatedMessa
     ttlMs: burst.ttlMs,
     stageId: burst.stageId,
     seed: burst.seed,
-    tMs: burst.tMs,
+    tMs: (burst.tMs !== undefined ? Number(burst.tMs) : clientTimestamp) + stampTimeOffset,
     progress: burst.progress || 0,
     targetTag: burst.targetTag || "center",
   }));

--- a/src/players/PlayerManager.ts
+++ b/src/players/PlayerManager.ts
@@ -100,8 +100,11 @@ export class PlayerManager {
                     if (before) {
                         player.car.isDrifting = before.drifting;
                     }
+                    player.lastRemoteSampleMs = interpolated.sampledTimeMs;
+                } else {
+                    player.lastRemoteSampleMs = null;
                 }
-                
+
                 // Prune old snapshots
                 player.snapshotBuffer.pruneOld(pruneBeforeMs);
             }

--- a/src/render/WorldRenderer.ts
+++ b/src/render/WorldRenderer.ts
@@ -41,6 +41,7 @@ export interface DrawFrameArgs {
     track: Track;
     worldScale: number;
     frameStepMs: number;
+    trailRenderTimeMs: number;
 }
 
 export class WorldRenderer {
@@ -141,7 +142,7 @@ export class WorldRenderer {
     }
 
     drawFrame(ctx: CanvasRenderingContext2D, args: DrawFrameArgs): void {
-        const { localPlayer, players, showCheckpoints, lapCounter, track, worldScale, frameStepMs } = args;
+        const { localPlayer, players, showCheckpoints, lapCounter, track, worldScale, frameStepMs, trailRenderTimeMs } = args;
 
         this.updatePopups(frameStepMs);
 
@@ -163,8 +164,17 @@ export class WorldRenderer {
 
         for (let id in players) {
             const player = players[id];
-            
+            const isLocalPlayer = player === localPlayer;
+            const cutoffTime = isLocalPlayer ? Number.POSITIVE_INFINITY : trailRenderTimeMs;
+
             while (player.pendingTrailStamps.length > 0) {
+                const nextStamp = player.pendingTrailStamps[0];
+                const stampTime = nextStamp.tMs ?? Number.NEGATIVE_INFINITY;
+
+                if (!isLocalPlayer && stampTime > cutoffTime) {
+                    break;
+                }
+
                 const stamp = player.pendingTrailStamps.shift()!;
                 player.car.trail.drawStamp(this.trails, stamp);
             }


### PR DESCRIPTION
## Summary
- add a render-time cutoff when consuming remote trail stamps so drift effects stay behind the car
- pass the interpolated render timestamp from the game loop to the world renderer for scheduling trails

## Testing
- npm test -- --watch=false *(fails: existing Score_class unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_68f016339b3c832da09635d7a2515e9c